### PR TITLE
feat: Retry sync on failure

### DIFF
--- a/JworkzNeosFixFrickenSync/JworkzNeosFixFrickenSync.cs
+++ b/JworkzNeosFixFrickenSync/JworkzNeosFixFrickenSync.cs
@@ -1,6 +1,8 @@
-﻿using NeosModLoader;
+﻿using System;
+using NeosModLoader;
 using HarmonyLib;
 using FrooxEngine;
+using JworkzNeosMod.Patches;
 
 namespace JworkzNeosMod
 {
@@ -14,6 +16,14 @@ namespace JworkzNeosMod
         [AutoRegisterConfigKey]
         private static readonly ModConfigurationKey<bool> KEY_ENABLE =
             new ModConfigurationKey<bool>("enabled", $"Enables the {nameof(JworkzNeosFixFrickenSync)} mod", () => true);
+
+        [AutoRegisterConfigKey]
+        private static readonly ModConfigurationKey<byte> KEY_RETRY_COUNT =
+            new ModConfigurationKey<byte>("retryCount", "The number of times to retry failed sync actions.", () => 3);
+
+        [AutoRegisterConfigKey]
+        private static readonly ModConfigurationKey<TimeSpan> KEY_RETRY_DELAY =
+            new ModConfigurationKey<TimeSpan>("retryDelay", "The delay between attempts to retry failed sync actions.", () => TimeSpan.Zero);
 
         private static ModConfiguration Config;
 
@@ -36,11 +46,17 @@ namespace JworkzNeosMod
             Config.OnThisConfigurationChanged += OnConfigurationChanged;
             Engine.Current.OnReady += OnCurrentNeosEngineReady;
 
+            RecordUploadTaskBasePatch.MaxUploadRetries = Config.GetValue(KEY_RETRY_COUNT);
+            RecordUploadTaskBasePatch.RetryDelay = Config.GetValue(KEY_RETRY_DELAY);
+
             _harmony.PatchAll();
         }
 
         private void RefreshMod()
         {
+            RecordUploadTaskBasePatch.MaxUploadRetries = Config.GetValue(KEY_RETRY_COUNT);
+            RecordUploadTaskBasePatch.RetryDelay = Config.GetValue(KEY_RETRY_DELAY);
+
             var isEnabled = Config.GetValue(KEY_ENABLE);
             ToggleHarmonyPatchState(isEnabled);
         }

--- a/JworkzNeosFixFrickenSync/Patches/RecordUploadTaskBasePatch.cs
+++ b/JworkzNeosFixFrickenSync/Patches/RecordUploadTaskBasePatch.cs
@@ -16,32 +16,58 @@ namespace JworkzNeosMod.Patches
         private static readonly FieldInfo _completionSourceField = AccessTools.Field(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "_completionSource");
         private static readonly MethodInfo _failMethod = AccessTools.Method(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "Fail");
 
+        internal static byte MaxUploadRetries { get; set; }
+        internal static TimeSpan RetryDelay { get; set; }
+
         [HarmonyPrefix]
         [HarmonyPatch("RunUpload")]
-        static bool RunUploadPrefix(RecordUploadTaskBase<FrooxEngine.Record> __instance, ref Task __result, CancellationToken cancellationToken)
+        static bool RunUploadPrefix(RecordUploadTaskBase<FrooxEngine.Record> __instance, out Task __result, CancellationToken cancellationToken)
         {
             var uploadTask = (Task)_runUploadInternalMethod.Invoke(__instance, new object[] { cancellationToken });
             var completionSource = (TaskCompletionSource<bool>)_completionSourceField.GetValue(__instance);
             var failMethod = _failMethod.CreateDelegate<Action<string>>(__instance);
 
-            __result = Task.Run(async () =>
-            {
-                try
+            // We don't want to let the task terminate early, so the cancellation token is not passed on
+            __result = Task.Run
+            (
+                async () =>
                 {
-                    NeosMod.Msg("Starting sync task...");
-                    await uploadTask.ConfigureAwait(false);
-                    NeosMod.Msg("Sync Upload Task is done");
-                    if (completionSource != null && !completionSource.Task.IsCompleted)
+                    var retryCount = 0;
+                    var maxRetryCount = MaxUploadRetries <= 0 ? 1 : MaxUploadRetries;
+                    var delay = RetryDelay;
+
+                    while (retryCount < maxRetryCount && !cancellationToken.IsCancellationRequested)
                     {
-                        completionSource.SetResult(__instance.IsFinished);
+                        try
+                        {
+                            await uploadTask.ConfigureAwait(false);
+                            _ = completionSource.TrySetResult(__instance.IsFinished);
+
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            NeosMod.Error($"Exception during record upload task (attempt {retryCount + 1} out of {maxRetryCount}): {ex}");
+                        }
+
+                        ++retryCount;
+                        await Task.Delay(delay, CancellationToken.None);
                     }
-                }
-                catch (Exception ex)
-                {
-                    NeosMod.Error($"Exception during record upload task:\n {ex?.ToString()}");
-                    failMethod($"Exception during sync.");
-                }
-            });
+
+                    // we may not have signalled completion at this point, so if we haven't, notify the system of failure
+                    if (!completionSource.Task.IsCompleted)
+                    {
+                        failMethod
+                        (
+                            cancellationToken.IsCancellationRequested
+                                ? "Record upload task cancelled"
+                                : "Exception during sync."
+                        );
+                    }
+                },
+                CancellationToken.None
+            );
+
             return false;
         }
     }

--- a/JworkzNeosFixFrickenSync/Patches/RecordUploadTaskBasePatch.cs
+++ b/JworkzNeosFixFrickenSync/Patches/RecordUploadTaskBasePatch.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using HarmonyLib;
 using System.Threading;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using CloudX.Shared;
 using MonoMod.Utils;
 using NeosModLoader;
@@ -15,6 +16,9 @@ namespace JworkzNeosMod.Patches
         private static readonly MethodInfo _runUploadInternalMethod = AccessTools.Method(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "RunUploadInternal");
         private static readonly FieldInfo _completionSourceField = AccessTools.Field(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "_completionSource");
         private static readonly MethodInfo _failMethod = AccessTools.Method(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "Fail");
+
+        private static readonly Regex _clientErrorMatcher = new Regex(@"state: 4\d\d", RegexOptions.Compiled);
+        private static readonly Regex _terminalServerErrorMatcher = new Regex(@"state: (501|505|511)", RegexOptions.Compiled);
 
         internal static byte MaxUploadRetries { get; set; }
         internal static TimeSpan RetryDelay { get; set; }
@@ -48,6 +52,11 @@ namespace JworkzNeosMod.Patches
                         catch (Exception ex)
                         {
                             NeosMod.Error($"Exception during record upload task (attempt {retryCount + 1} out of {maxRetryCount}): {ex}");
+
+                            if (!__instance.ShouldRetry())
+                            {
+                                break;
+                            }
                         }
 
                         ++retryCount;
@@ -69,6 +78,23 @@ namespace JworkzNeosMod.Patches
             );
 
             return false;
+        }
+
+        private static bool ShouldRetry(this RecordUploadTaskBase<FrooxEngine.Record> uploadTask)
+        {
+            switch (uploadTask.FailReason.Trim().ToLowerInvariant())
+            {
+                case var r1 when r1.Contains("conflict"):
+                case var r2 when r2.Contains("preprocessing failed"):
+                    return false;
+                case var r3 when r3.Contains("state: 429"):
+                    return true; // catch this before the next line
+                case var r4 when _clientErrorMatcher.IsMatch(r4):
+                case var r5 when _terminalServerErrorMatcher.IsMatch(r5):
+                    return false;
+                default:
+                    return true;
+            }
         }
     }
 }

--- a/JworkzNeosFixFrickenSync/Patches/RecordUploadTaskBasePatch.cs
+++ b/JworkzNeosFixFrickenSync/Patches/RecordUploadTaskBasePatch.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using HarmonyLib;
-using FrooxEngine;
 using System.Threading;
 using System.Reflection;
 using CloudX.Shared;
 using MonoMod.Utils;
-using BaseX;
 using NeosModLoader;
 
 namespace JworkzNeosMod.Patches
@@ -17,72 +12,17 @@ namespace JworkzNeosMod.Patches
     [HarmonyPatch(typeof(RecordUploadTaskBase<FrooxEngine.Record>))]
     internal static class RecordUploadTaskBasePatch
     {
-        private static MethodInfo _runUploadInternalMethod;
-
-        private static FieldInfo _completionSourceFieldInfo;
-
-        private static MethodInfo _isFinishedGetterMethodInfo;
-
-        private static MethodInfo _failMethodInfo;
-
-        public static MethodInfo RunUploadInternalMethod
-        {
-            get
-            {
-                if (_runUploadInternalMethod == null)
-                {
-                    _runUploadInternalMethod = AccessTools.Method(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "RunUploadInternal", new[] { typeof(CancellationToken) });
-                }
-
-                return _runUploadInternalMethod;
-            }
-        }
-
-        public static FieldInfo GetCompletionSourceInfo
-        {
-            get
-            {
-                if (_completionSourceFieldInfo == null)
-                {
-                    _completionSourceFieldInfo = AccessTools.Field(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "_completionSource");
-                }
-
-                return _completionSourceFieldInfo;
-            }
-        }
-
-        public static MethodInfo IsFinishedGetterInfo
-        {
-            get
-            {
-                if (_isFinishedGetterMethodInfo == null)
-                {
-                    _isFinishedGetterMethodInfo = AccessTools.PropertyGetter(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "IsFinished");
-                }
-                return _isFinishedGetterMethodInfo;
-            }
-        }
-
-        public static MethodInfo FailInfo
-        {
-            get
-            {
-                if (_failMethodInfo == null)
-                {
-                    _failMethodInfo = AccessTools.Method(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "Fail");
-                }
-                return _failMethodInfo;
-            }
-        }
+        private static readonly MethodInfo _runUploadInternalMethod = AccessTools.Method(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "RunUploadInternal");
+        private static readonly FieldInfo _completionSourceField = AccessTools.Field(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "_completionSource");
+        private static readonly MethodInfo _failMethod = AccessTools.Method(typeof(RecordUploadTaskBase<FrooxEngine.Record>), "Fail");
 
         [HarmonyPrefix]
         [HarmonyPatch("RunUpload")]
-        static bool RunUploadPrefix(ref RecordUploadTaskBase<FrooxEngine.Record> __instance, ref Task __result, CancellationToken cancellationToken)
+        static bool RunUploadPrefix(RecordUploadTaskBase<FrooxEngine.Record> __instance, ref Task __result, CancellationToken cancellationToken)
         {
-            var uploadTask = RunUploadInternalMethod.Invoke(__instance, new object[] { cancellationToken }) as Task;
-            var completionSource = GetCompletionSourceInfo.GetValue(__instance) as TaskCompletionSource<bool>;
-            var isFinishedGetter = IsFinishedGetterInfo.CreateDelegate(typeof(Func<bool>), __instance);
-            var failMethod = FailInfo.CreateDelegate<Action<string>>(__instance);
+            var uploadTask = (Task)_runUploadInternalMethod.Invoke(__instance, new object[] { cancellationToken });
+            var completionSource = (TaskCompletionSource<bool>)_completionSourceField.GetValue(__instance);
+            var failMethod = _failMethod.CreateDelegate<Action<string>>(__instance);
 
             __result = Task.Run(async () =>
             {
@@ -93,8 +33,7 @@ namespace JworkzNeosMod.Patches
                     NeosMod.Msg("Sync Upload Task is done");
                     if (completionSource != null && !completionSource.Task.IsCompleted)
                     {
-                        var isFinished = (bool)isFinishedGetter.DynamicInvoke();
-                        completionSource.SetResult(isFinished);
+                        completionSource.SetResult(__instance.IsFinished);
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
This PR backports changes from Remora.Neos.Headless's adaption of this mod, adding the ability to retry failed sync operations. By default, the retry logic is set to retry up to three times with no delay between failures. Some errors are non-retryable and are detected with a small helper method, though it's only a best effort without any true guarantees.

These values can be configured with the `retryCount` and `retryDelay` configuration options.

Additionally, the patch is cleaned up in general, removing redundant code and tightening mutability. 

This code is contributed under the original mod's MIT license, not Remora.Neos.Headless's AGPL license.